### PR TITLE
Fix a problem with loading services via broker.loadServices

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   Action,
   ActionHandler,
   LoggerInstance,
+  Service as MoleculerService,
   ServiceMethods,
   ServiceEvents,
   Actions,
@@ -105,7 +106,9 @@ export function Service(options: Options = {}): Function {
   return function(constructor: Function
   ) {
 
-    let base = () => {};
+    let base: ServiceSchema = {
+      name: '' // will be overridden
+    };
     const _options = _.extend({}, defaultServiceOptions, options);
 
     Object.defineProperty(base, 'name', {
@@ -199,6 +202,10 @@ export function Service(options: Options = {}): Function {
       }
     });
 
-    return base;
+    return class extends MoleculerService {
+      constructor(broker) {
+        super(broker, base);
+      }
+    }
   };
 }

--- a/test/moleculer.spec.ts
+++ b/test/moleculer.spec.ts
@@ -2,26 +2,41 @@ import { ServiceBroker } from 'moleculer';
 import * as request from 'supertest';
 
 describe('Moleculer', () => {
+  const broker = new ServiceBroker();
+
+  beforeAll(() => {
+    return broker.start();
+  });
+
+  afterAll(() => {
+    return broker.stop();
+  });
+
   describe('Test auth', () => {
     const VALID_TOKEN = '123';
-    const broker = new ServiceBroker();
     const api = require('./services/api.service');
     const get = require('./services/get.service');
     broker.createService(get);
     const apiService = broker.createService(api);
-
-    beforeAll(() => {
-      return broker.start();
-    });
-
-    afterAll(() => {
-      return broker.stop();
-    });
 
     it('should pass auth', async () => {
       return request(apiService.server).get('/getTest/getModel/5')
         .set('Authorization', VALID_TOKEN)
         .expect(200);
     });
+  });
+
+  // when running via moleculer-runner, broker creates services with loadService
+  describe('Load services', () => {
+
+    it('should load the services', () => {
+      expect(broker.loadService('test/services/get.service.ts'))
+        .toBeDefined();
+    });
+
+    it('should load the service dir', () => {
+      expect(broker.loadServices('test/services', '*.service.ts'))
+        .toEqual(2);
+    })
   });
 });

--- a/test/services/get.service.ts
+++ b/test/services/get.service.ts
@@ -33,6 +33,10 @@ class GetTest extends BaseSchema {
   private _getModel(withUser: string, fromUser: string): Promise<User> {
     return Promise.resolve({id: '5'});
   }
+
+  private created(): void {
+    this.logger.info('Successfully created!');
+  }
 }
 
 module.exports = GetTest;


### PR DESCRIPTION
When running under moleculer-runner, the services are loaded with `broker.loadService()` function, instead of `broker.createService()`.
The problem was with Service decorator, that returns anonymous function `() => {}`, which was incorrectly handled in moleculer service broker

https://github.com/moleculerjs/moleculer/blob/6dd6c363decaf73c6cea622d51f8eb9256b5f754/src/service-broker.js#L550

and resulted in error in broker.createService()

```
Cannot read property 'prototype' of undefined TypeError: Cannot read property 'prototype' of undefined
    at ServiceBroker.getConstructorName (/home/node/app/node_modules/moleculer/src/service-broker.js:1317:20)
    at ServiceBroker.normalizeSchemaConstructor (/home/node/app/node_modules/moleculer/src/service-broker.js:1342:21)
    at ServiceBroker.createService (/home/node/app/node_modules/moleculer/src/service-broker.js:628:17)
    at ServiceBroker.loadService (/home/node/app/node_modules/moleculer/src/service-broker.js:554:16)
```

I've introduced more native way how to decorate a moleculer service into standard ES6 service
