### PR TITLE
Extend a Service from a valid ServiceFactory class

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ skipHandler: true // false by default, this will let a mixin override the handle
 
 ```js
 const moleculer = require('moleculer');
-const { Service, Action, Event, Method, BaseSchema } = require('moleculer-decorators');
+const { Service, Action, Event, Method } = require('moleculer-decorators');
 const web = require('moleculer-web');
 const broker = new moleculer.ServiceBroker({
   logger: console,
@@ -36,7 +36,7 @@ const broker = new moleculer.ServiceBroker({
     ]
   }
 })
-class ServiceName extends BaseSchema { // Only need to extend if you are using typescript for intellisense support.
+class ServiceName extends moleculer.Service {
 
   // Optional constructor
   constructor() {
@@ -115,6 +115,41 @@ broker.start();
 ```js 
   module.exports = ServiceName 
 ``` 
+
+## Usage with custom ServiceFactory class
+> Moleculer allows you to define your own ServiceFactory class, from which your services should inherit. 
+> All you have to do, is pass your custom ServiceFactory to broker options and also extend your services from this class 
+```js
+const moleculer = require('moleculer');
+const { Service, Action } = require('moleculer-decorators');
+
+// create new service factory, inheriting from moleculer native Service
+class CustomService extends moleculer.Service {
+    constructor(broker, schema) {
+        super(broker, schema)
+    }
+
+    foo() {
+        return 'bar';
+    }
+}
+
+// pass your custom service factory to broker options
+const broker = new moleculer.ServiceBroker({
+  ServiceFactory: CustomService
+});
+
+@Service()
+class ServiceName extends CustomService { // extend your service from your custom service factory
+  @Action()
+  Bar(ctx) {
+    return this.foo();
+  }
+}
+
+broker.createService(CustomService);
+broker.start();
+```
 
 # License
 Moleculer Decorators is available under the [MIT license](https://tldrlegal.com/license/mit-license).

--- a/test/customServices/CustomServiceFactory.ts
+++ b/test/customServices/CustomServiceFactory.ts
@@ -1,0 +1,15 @@
+import { Service } from 'moleculer';
+
+class CustomService extends Service {
+  constructor(broker, schema) {
+    super(broker, schema)
+  }
+
+  foo() {
+    return 'bar';
+  }
+}
+
+export {
+    CustomService
+}

--- a/test/customServices/custom.service.ts
+++ b/test/customServices/custom.service.ts
@@ -1,0 +1,19 @@
+import * as Moleculer from 'moleculer';
+import { CustomService } from './CustomServiceFactory';
+import { Action, Service } from '../../src';
+import 'reflect-metadata';
+
+
+@Service()
+class CustomTest extends CustomService {
+  @Action()
+  public async testAction(_ctx: Moleculer.Context) {
+    return this.foo()
+  }
+
+  private created(): void {
+    this.logger.info('Successfully created!');
+  }
+}
+
+module.exports = CustomTest;

--- a/test/services/api.service.ts
+++ b/test/services/api.service.ts
@@ -1,7 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http';
-import { Context } from 'moleculer';
 import * as Moleculer from 'moleculer';
-import { BaseSchema, Method, Service } from '../../src';
+import { Method, Service } from '../../src';
 import * as ApiGateway from 'moleculer-web';
 import 'reflect-metadata';
 
@@ -28,9 +27,9 @@ const {Errors} = ApiGateway;
     ]
   }
 })
-class Api extends BaseSchema {
+class Api extends Moleculer.Service {
   @Method
-    public async authenticate(ctx: Context, route: string, req: IncomingMessage, res: ServerResponse) {
+    public async authenticate(ctx: Moleculer.Context, route: string, req: IncomingMessage, res: ServerResponse) {
     const accessToken = req.headers.authorization;
     if (accessToken) {
       const user = await this._getUserFromRemoterService(ctx, accessToken);

--- a/test/services/get.service.ts
+++ b/test/services/get.service.ts
@@ -1,5 +1,5 @@
-import { Context, GenericObject } from 'moleculer';
-import { Action, BaseSchema, Method, Service } from '../../src';
+import * as Moleculer from 'moleculer';
+import { Action, Method, Service } from '../../src';
 import { User } from './api.service';
 import 'reflect-metadata';
 interface ChatsActionParams {
@@ -11,13 +11,13 @@ export interface AuthMeta {
   $statusCode?: number;
 }
 
-export interface AuthContext<P = GenericObject> extends Context<P, AuthMeta> {
+export interface AuthContext<P = Moleculer.GenericObject> extends Moleculer.Context<P, AuthMeta> {
   meta: AuthMeta;
   params: P;
 }
 
 @Service()
-class GetTest extends BaseSchema {
+class GetTest extends Moleculer.Service {
   @Action({
     params: {
       withUser: 'string'


### PR DESCRIPTION
Recently, I had to create my own Service class that I wanted to pass to Moleculer's broker options 
```js
const broker = new ServiceBroker({
  ServiceFactory: CustomService
});
```
but it resulted in an error in broker when creating a class. It went down at this condition
```js
if (this.ServiceFactory.isPrototypeOf(schema))
```
and clearly, our decorated services aren't prototyped from a ServiceFactory class. They aren't extended even from a moleculer native Service class. We are extending from a `BaseSchema` which isn't a service class (it was meant for an intellisense support)

In this pull request, I've fixed this problem. 

Service developers now **have to extend** their service from a native `moleculer Service` (and not from a `BaseSchema`), just as it is in a moleculer ES6 services, so they are now more compatible.
Also, developer can extend from his own ServiceFactory class, that he passed to broker options

I've updated a README.md and also wrote a unit tests, covering this case.
Thank you for merge 