### PR TITLE
feat: add generic for Service decorator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,8 @@ export function Action(options: ActionOptions = {}) {
 // Instead of using moleculer's ServiceBroker, we will fake the broker class to pass it to service constructor
 const mockServiceBroker = new Object({ Promise });
 
-export function Service(options: Options = {}): Function {
+export function Service<T extends Options>(opts: T): Function {
+  const options = opts || {} as Options;
   return function(constructor: Function) {
     let base: ServiceSchema = {
       name: "" // will be overridden


### PR DESCRIPTION
Adding generic in @Service decorator, you could have this use case:

```typescript
export interface UserJWT {
  _id: string;
  login: string;
  firstName: string;
  lastName?: string;
  email: string;
}

interface UserServiceSettingsOptions {
  rest: '/api/user/';
  JWT_SECRET: string;
  fields: (keyof Required<UserJWT>)[];
}

export interface UsersServiceOptions extends Options {
  name: 'users';
  settings: UserServiceSettingsOptions;
}

@Service<UsersServiceOptions>({
  name: 'users',
  mixins: [dbUsersMixin, eventsMixin],
  settings: {
    rest: '/api/user/',
    JWT_SECRET: 'my-secret',
    fields: ['_id', 'login', 'firstName', 'lastName', 'email']
  }
})
```

Then if you need to remove a field for user, you only need to change UserJWT interface, for example, "email"

![image](https://user-images.githubusercontent.com/1378986/81498442-45792000-92c5-11ea-9fff-340b0f28a97f.png)


