### PR TITLE
Allow for custom queue decorators

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ export function Service<T extends Options>(opts: T = {} as T): Function {
         return;
       }
 
-      if (key === "events" || key === "methods" || key === "actions") {
+      if (key === "events" || key === "methods" || key === "actions" || key === "queues") {
         base[key]
           ? Object.assign(base[key], descriptor.value)
           : (base[key] = descriptor.value);


### PR DESCRIPTION
Hello

I'm using `moleculer-bee-queue` (https://www.npmjs.com/package/moleculer-bee-queue) and have created my own decorator (`@Queue()`) but I needed to make this change to allow for the queues to not be stripped.