### PR TITLE
Allow service name to be writable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export function Service<T extends Options>(opts: T = {} as T): Function {
 
     Object.defineProperty(base, "name", {
       value: options.name || constructor.name,
-      writable: false,
+      writable: true,
       enumerable: true,
     });
 


### PR DESCRIPTION
```typescript
import Moleculer from "moleculer";
import { Service } from "moleculer-decorators";

import HttpGateway from "moleculer-web";

@Service()
export default class HttpService extends Moleculer.Service {
	public mixins: any = [HttpGateway]
	public name = "http";
}
```
This change allows the above name assignment to work; without this change it throws an error about writing to a read only field.