### PR TITLE
fix issue when using constructor with custom arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -193,8 +193,8 @@ export function Service<T extends Options>(opts: T = {} as T): Function {
     });
 
     return class extends parentService.constructor {
-      constructor(broker, schema) {
-        super(broker, schema);
+      constructor(broker, ...args) {
+        super(broker, ...args);
         this.parseServiceSchema(base);
       }
     };


### PR DESCRIPTION
Problem:
When i use constructor with some custom arguments like this:

```
@Service({
    name: 'hello-service',
    constructOverride: false,
})
class HelloService extends moleculer.Service {
    constructor(broker: ServiceBroker, private readonly param1: string, private readonly param2: string) {
        super(broker);
    }

    @Action({
        name: 'say.hello',
    })
    async sayHello() {
        return 'Hello!';
    }
}
```

any additional parameters are lost because only 2 parameters are passed to the superclass.

